### PR TITLE
mvp: keep previous metrics when fetch fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-02-xx (v0.4.0)
+
+  * 10 second timeout for fetching data
+  * Keep previous metrics when a fetch fails (or times out).
+
 ## 2024-02-09 (v0.3.1)
 
   * Container based on python 3.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
   * 10 second timeout for fetching data
   * Keep previous metrics when a fetch fails (or times out).
+  * Metrics duration now tracks fetching time, not web request delay.
+  * Uses locking to prevent concurrent update requests
 
 ## 2024-02-09 (v0.3.1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sagemcom-f3896-client"
-version = "0.3.1"
+version = "0.4.0"
 description = ""
 authors = ["Ties de Kock <ties@tiesdekock.nl>"]
 readme = "README.md"


### PR DESCRIPTION
A minimal viable product of keeping the metrics from the previous fetch when the update fails. Fixes #13 